### PR TITLE
feat: add reusable Button component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,9 +13,9 @@
   --button-donate-bg-color: transparent;
   --button-donate-hover-color: transparent;
 
-  --button-slider-border-rad: 24px;
+  --button-slider-border-rad: 48px;
   --button-slider-color: #151515;
-  --button-slider-hover-color: #f5f5f5;
+  --button-slider-hover-color: linear-gradient(90deg, #baded3 0%, #abd1e7 100%);
 
   --button-form-border-rad: 12px;
   --button-form-color: #151515;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
 import "./globals.css";
 import "./normalize.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Open_Sans } from "next/font/google";
 
-const inter = Inter({ subsets: ["latin"] });
+const open_sans = Open_Sans({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "",
@@ -17,7 +17,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={open_sans.className}>{children}</body>
     </html>
   );
 }

--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -31,8 +31,6 @@
 /* styles for donateBtn */
 .donateBtn {
   border-radius: var(--button-primary-border-rad);
-  width: 169px;
-  height: 55px;
 }
 
 /* Hover and focus styles for donateBtn */

--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -1,0 +1,69 @@
+/* Default button styles */
+.button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  padding: var(--button-primary-padding);
+  background-color: var(--button-primary-color);
+
+  color: var(--bg-primary-color);
+  font-size: 20px;
+  font-weight: 600;
+
+  border: none;
+
+  cursor: pointer;
+}
+
+/* Full width styles */
+.button.fullWidth {
+  width: 100%;
+}
+
+/* Styles for disabled button */
+.button:disabled {
+  border-radius: var(--button-primary-border-rad);
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* styles for donateBtn */
+.donateBtn {
+  border-radius: var(--button-primary-border-rad);
+  width: 169px;
+  height: 55px;
+}
+
+/* Hover and focus styles for donateBtn */
+.donateBtn:hover:not(:disabled),
+.donateBtn:focus:not(:disabled) {
+  background-color: var(--button-donate-bg-color);
+  color: var(--button-donate-color);
+  border: 3px solid var(--button-donate-color);
+}
+
+/* styles for sliderBtn */
+.sliderBtn {
+  font-size: 18px;
+  border-radius: var(--button-slider-border-rad);
+}
+
+/* Hover and focus styles for sliderBtn */
+.sliderBtn:hover:not(:disabled),
+.sliderBtn:focus:not(:disabled) {
+  background: var(--button-slider-hover-color);
+  color: var(--button-donate-color);
+}
+
+/* styles for formBtn */
+.formBtn {
+  border-radius: var(--button-form-border-rad);
+}
+
+/* Hover and focus styles for formBtn */
+.formBtn:hover:not(:disabled),
+.formBtn:focus:not(:disabled) {
+  background-color: var(--button-form-hover-color);
+  color: var(--button-donate-color);
+}

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,0 +1,46 @@
+import styles from "./Button.module.css";
+
+export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isFullWidth?: boolean;
+  disabled?: boolean;
+  children: string;
+  width?: string;
+  height?: string;
+  donateBtn?: boolean;
+  sliderBtn?: boolean;
+  formBtn?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const Button: React.FC<Props> = ({
+  isFullWidth,
+  disabled,
+  children,
+  onClick,
+  width,
+  height,
+  donateBtn,
+  sliderBtn,
+  formBtn,
+  ...rest
+}) => {
+  const buttonClassName = `${styles.button} ${
+    isFullWidth ? styles.fullWidth : ""
+  } ${donateBtn ? styles.donateBtn : ""} ${sliderBtn ? styles.sliderBtn : ""} ${
+    formBtn ? styles.formBtn : ""
+  }`;
+
+  return (
+    <button
+      onClick={onClick}
+      className={buttonClassName}
+      disabled={disabled}
+      style={{ width: width, height: height }}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
Реалізувала кастомну кнопку, що приймає дефолтні та кастомні пропси. Поведінка має відповідати очікуванням користувача. 

Кнопка має:
- hover/focus,
- disabled;
- Приймає ширину та висоту за замовчуванням вона по контенту в середині
- Пропс isFullWidth
- Кнопка відповідає дизайну

![disabled](https://github.com/baza-trainee/remote-demining/assets/99128741/789e291d-4815-4ef9-a9b8-453d044984ce)
![donateBtn_hover](https://github.com/baza-trainee/remote-demining/assets/99128741/f9a27439-0637-41f4-85de-92b14887f333)
![formBtn](https://github.com/baza-trainee/remote-demining/assets/99128741/1a89ce90-bf39-4247-b742-c162e6a45e80)
![formBtn_hover](https://github.com/baza-trainee/remote-demining/assets/99128741/52e08b16-e858-4c86-9cd1-c7cd70acd6f1)
![Screenshot_1](https://github.com/baza-trainee/remote-demining/assets/99128741/5ab1ae25-2864-45db-926b-ab8d6c69488f)
![sliderBtn](https://github.com/baza-trainee/remote-demining/assets/99128741/ae8141f3-ef4b-48a1-b73c-cc872d052381)
![sliderBtn_hover](https://github.com/baza-trainee/remote-demining/assets/99128741/ae75e42e-af55-482d-97d9-2656293da469)
