### PR TITLE
fix imports order in AboutSection

### DIFF
--- a/components/AboutSection/AboutSection.tsx
+++ b/components/AboutSection/AboutSection.tsx
@@ -1,14 +1,14 @@
-import SectionContainer from "../SectionContainer/SectionContainer"
-import AboutSectionList from "./AboutSectionList/AboutSectionList"
+import SectionContainer from "../SectionContainer/SectionContainer";
 
-import aboutData from "./aboutData"
+import AboutSectionList from "./AboutSectionList/AboutSectionList";
+import aboutData from "./aboutData";
 
 const AboutSection: React.FC = () => {
   return (
     <SectionContainer>
-        <AboutSectionList items={ aboutData } />
+      <AboutSectionList items={aboutData} />
     </SectionContainer>
-  )
-}
+  );
+};
 
-export default AboutSection
+export default AboutSection;

--- a/components/AboutSection/AboutSectionItem/AboutSectionItem.tsx
+++ b/components/AboutSection/AboutSectionItem/AboutSectionItem.tsx
@@ -1,5 +1,6 @@
-import CustomLink from '@/components/CustomLink/CustomLink';
-import css from './aboutSectionItem.module.css';
+import CustomLink from "@/components/CustomLink/CustomLink";
+
+import css from "./aboutSectionItem.module.css";
 
 interface AboutSectionItemProps {
   text: string;
@@ -14,11 +15,11 @@ const AboutSectionItem: React.FC<AboutSectionItemProps> = ({ img, text }) => {
   return (
     <li className={css.aboutItem}>
       <div className={css.contentWrapper}>
-          <picture>
-            <source media="(max-width: 767px)" srcSet={img.small} />
-            <source media="(max-width: 1439px)" srcSet={img.medium} />
-            <img src={img.large} alt="About Us" className={css.image} />
-          </picture>
+        <picture>
+          <source media="(max-width: 767px)" srcSet={img.small} />
+          <source media="(max-width: 1439px)" srcSet={img.medium} />
+          <img src={img.large} alt="About Us" className={css.image} />
+        </picture>
         <div className={css.imgDescription}>
           <p className={css.text}>{text}</p>
           <CustomLink href="#" isFullWidth>
@@ -31,4 +32,3 @@ const AboutSectionItem: React.FC<AboutSectionItemProps> = ({ img, text }) => {
 };
 
 export default AboutSectionItem;
-

--- a/components/AboutSection/AboutSectionList/AboutSectionList.tsx
+++ b/components/AboutSection/AboutSectionList/AboutSectionList.tsx
@@ -1,11 +1,15 @@
-import AboutSectionItem from '../AboutSectionItem/AboutSectionItem';
+import AboutSectionItem from "../AboutSectionItem/AboutSectionItem";
 
-import css from './aboutSectionList.module.css'
+import css from "./aboutSectionList.module.css";
 
 interface AboutSectionListProps {
   items: {
     id: number;
-    img: string;
+    img: {
+      small: string;
+      medium: string;
+      large: string;
+    };
     text: string;
   }[];
 }
@@ -17,7 +21,7 @@ const AboutSectionList: React.FC<AboutSectionListProps> = ({ items }) => {
         <AboutSectionItem key={item.id} img={item.img} text={item.text} />
       ))}
     </ul>
-  )
-}
+  );
+};
 
-export default AboutSectionList
+export default AboutSectionList;


### PR DESCRIPTION
Через новий плагін, який сортує імпорти, виникла помилка під час білда. Я пофіксила порядок імпортів і тепер все повинно працювати. Також внесла невеликі змінни у тип img в interface AboutSectionListProps, замість string прописала об'єкт.