### PR TITLE
feat: add outlined button variant

### DIFF
--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -41,3 +41,19 @@
   background-color: var(--button-disabled-bg-color);
   cursor: not-allowed;
 }
+
+.button.outlined {
+  background-color: transparent;
+  box-shadow: 0 0 0 1px var(--button-primary-bg-color);
+  color: var(--button-primary-bg-color);
+}
+
+.button.outlined:hover {
+  background-color: var(--button-primary-hover-color);
+  box-shadow: 0 0 0 2px var(--button-primary-bg-color);
+}
+
+.button.outlined:active {
+  background-color: var(--button-primary-bg-color);
+  color: var(--button-primary-color);
+}

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -7,6 +7,7 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: string;
   width?: string;
   height?: string;
+  outlined?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -18,12 +19,14 @@ const Button: React.FC<Props> = ({
   width,
   height,
   className,
+  outlined,
   ...rest
 }) => {
   // const buttonClassName = `${styles.button} ${isFullWidth && styles.fullWidth}`;
   const buttonClassName = classNames(
     styles.button,
     isFullWidth && styles.fullWidth,
+    outlined && styles.outlined,
     className
   );
 


### PR DESCRIPTION
Outlined варіант кнопки має звичайний стан, ховер та активний

![active](https://github.com/baza-trainee/remote-demining/assets/68874586/54d7d801-b708-4c56-ab8e-d5b21fd3f7e2)
![normal](https://github.com/baza-trainee/remote-demining/assets/68874586/60950c26-17c8-47ee-96f6-9598a9b688ff)
![hover](https://github.com/baza-trainee/remote-demining/assets/68874586/b6be5bb1-9f01-47b6-840d-0e3d1e89102c)
