### PR TITLE
refactor: add 2 size types to AdminWrapper

### DIFF
--- a/components/AdminWrapper/AdminWrapper.module.css
+++ b/components/AdminWrapper/AdminWrapper.module.css
@@ -1,6 +1,16 @@
 .wrapper {
-  min-height: 1014px;
   background-color: var(--bg-white-color);
-  padding: 32px 24px;
   border-radius: 20px;
+}
+
+.bigWrapper {
+  min-height: 556px;
+  width: 1014px;
+  padding: 32px 24px;
+}
+
+.smallWrapper {
+  min-height: 434px;
+  width: 391px;
+  padding: 50px 50px 40px;
 }

--- a/components/AdminWrapper/AdminWrapper.tsx
+++ b/components/AdminWrapper/AdminWrapper.tsx
@@ -1,11 +1,23 @@
 import styles from "./AdminWrapper.module.css";
 
+type WrapperSize = "bigWrapper" | "smallWrapper";
+
 interface WrapperProps {
   children: React.ReactNode;
+  size: WrapperSize;
+  classname?: string;
 }
 
-const AdminWrapper: React.FC<WrapperProps> = ({ children }) => {
-  return <div className={styles.wrapper}>{children}</div>;
+const AdminWrapper: React.FC<WrapperProps> = ({
+  children,
+  size,
+  classname,
+}) => {
+  return (
+    <div className={`${styles.wrapper} ${styles[size]} ${classname || ""}`}>
+      {children}
+    </div>
+  );
 };
 
 export default AdminWrapper;


### PR DESCRIPTION
Переробила AdminWrapper, щоб це був перевикористовуваний компонент одночасно для малих і великих форм