### PR TITLE
Bugfix/fix team slider

### DIFF
--- a/components/Slider/Arrow/Arrow.tsx
+++ b/components/Slider/Arrow/Arrow.tsx
@@ -4,32 +4,17 @@ import styles from "./Arrow.module.css";
 
 interface ArrowProps extends CustomArrowProps {
   arrowType: "next" | "prev";
-  infinite?: boolean;
-  slidesPerPage: number;
 }
 
-const Arrow: React.FC<ArrowProps> = ({
-  arrowType,
-  className,
-  style,
-  currentSlide,
-  slideCount,
-  infinite,
-  slidesPerPage,
-  ...props
-}) => {
-  const isDisabled =
-    !infinite &&
-    (arrowType === "next"
-      ? currentSlide === (slideCount as number) - slidesPerPage
-      : currentSlide === 0);
+const Arrow: React.FC<ArrowProps> = ({ arrowType, onClick }) => {
+  const isDisabled = !onClick;
   return (
     <button
       className={styles[arrowType === "next" ? "arrow-next" : "arrow-prev"]}
       disabled={isDisabled}
       aria-disabled={isDisabled}
       type="button"
-      {...props}
+      onClick={onClick}
     >
       {arrowType === "next" ? (
         <svg

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -27,20 +27,8 @@ const Slider: React.FC<SliderProps> = ({
     slidesToShow: slidesPerPage < slides.length ? slidesPerPage : slides.length,
     autoplay: false,
     focusOnSelect: false,
-    nextArrow: (
-      <Arrow
-        arrowType="next"
-        slidesPerPage={slidesPerPage}
-        infinite={infinite}
-      />
-    ),
-    prevArrow: (
-      <Arrow
-        arrowType="prev"
-        slidesPerPage={slidesPerPage}
-        infinite={infinite}
-      />
-    ),
+    nextArrow: <Arrow arrowType="next" />,
+    prevArrow: <Arrow arrowType="prev" />,
     arrows: true,
     appendDots: (dots) => (
       <ul style={{ bottom: dotsPlacement === "outer" ? -16 : 16 }}>{dots}</ul>

--- a/components/Team/Team.tsx
+++ b/components/Team/Team.tsx
@@ -17,12 +17,7 @@ const Team: React.FC = () => {
       bgImg={teamBg.src}
       centerTitle
     >
-      <Slider
-        slides={cardsData}
-        slidesPerPage={4}
-        infinite={true}
-        responsive={responsive}
-      />
+      <Slider slides={cardsData} slidesPerPage={4} responsive={responsive} />
     </SectionContainer>
   );
 };


### PR DESCRIPTION
пофіксив баг з обрізанням першої картки членів наукової ради. баг був пов'язаний з тим, що нескінченний слайдер завжди пропорційно розташовує елементи зліва і справа, тож треба було зробити його звичайним. також пофіксив помічений баг із тим, що стрілки неправильно показувалися і працювали на різних брейкпоінтах